### PR TITLE
make all ports expoest at docker

### DIFF
--- a/lib/hbclient.py
+++ b/lib/hbclient.py
@@ -252,18 +252,14 @@ class HBClient(object):
 
         uri = manifest["imageUri"]
         options = manifest["containerCreateOptions"]
-        port_bindings = options ["HostConfig"]["PortBindings"]
+        port_bindings = options["HostConfig"]["PortBindings"]
         
+        ports = {}
         for port_int, port_list in port_bindings.items(): 
-            port_ext = port_list[0]["HostPort"]
-
-        print(port_ext)
-        print(port_int)
-        print(uri)
-        
-        ports = {port_int : port_ext}
+            ports[port_int] = [entry["HostPort"] for entry in port_list]
         print (ports)
-        
+
+        print(uri)
         self.docker_client = docker.from_env()
         client = docker.from_env()
         


### PR DESCRIPTION
please have a look.

it converts from:

```JSON
      "HostConfig": {
          "PortBindings": {
              "5001/tcp": [
                  {
                      "HostPort": "51001"
                  },
                  {
                      "HostPort": "51002"
                  }
              ],
             "4001/tcp": [
                  {
                      "HostPort": "4001"
                  }
              ]
          },
          "Memory": 0
      }
```

To:

```python
ports = {
  "5001/tcp": ["51001", "51002"],
  "4001/tcp": ["4001"]
}
```

matching to the Docker docs:
```
ports (dict): Ports to bind inside the container.  

        The keys of the dictionary are the ports to bind inside the  
        container, either as an integer or a string in the form  
        `port/protocol`, where the protocol is either `tcp`,  
        `udp`, or `sctp`.  

        The values of the dictionary are the corresponding ports to  
        open on the host, which can be either:  

        - The port number, as an integer. For example,  
          `{'2222/tcp': 3333}` will expose port 2222 inside the  
          container as port 3333 on the host.  
        - `None`, to assign a random host port. For example,  
          `{'2222/tcp': None}`.  
        - A tuple of `(address, port)` if you want to specify the  
          host interface. For example,  
          `{'1111/tcp': ('127.0.0.1', 1111)}`.  
        - A list of integers, if you want to bind multiple host ports  
          to a single container port. For example,  
          `{'1111/tcp': [1234, 4567]}`.
```

